### PR TITLE
Support TreatMissingData for CloudWatch

### DIFF
--- a/lib/radiosonde/dsl/context/alarm.rb
+++ b/lib/radiosonde/dsl/context/alarm.rb
@@ -123,4 +123,14 @@ class Radiosonde::DSL::Context::Alarm
     _expected_type(actions, Array)
     @result.insufficient_data_actions = [(actions || [])].flatten
   end
+
+  def treat_missing_data(value)
+    _call_once(:treat_missing_data)
+    _validate("Invalid value: #{value}") do
+      Radiosonde::DSL::TreatMissingData.valid?(value)
+    end
+
+    @result.treat_missing_data = Radiosonde::DSL::TreatMissingData.normalize(value)
+  end
+
 end

--- a/lib/radiosonde/dsl/converter.rb
+++ b/lib/radiosonde/dsl/converter.rb
@@ -1,4 +1,5 @@
 require 'radiosonde/dsl/unit'
+require 'radiosonde/dsl/treat_missing_data'
 
 class Radiosonde::DSL::Converter
   class << self
@@ -42,6 +43,11 @@ class Radiosonde::DSL::Converter
       unit = "unit #{unit}\n"
     end
 
+    if treat_missing_data = attrs[:treat_missing_data]
+      treat_missing_data = Radiosonde::DSL::TreatMissingData.conv_to_alias(treat_missing_data).inspect
+      treat_missing_data = "treat_missing_data #{treat_missing_data}\n"
+    end
+
     <<-EOS
 alarm #{name} do
   #{description
@@ -51,7 +57,8 @@ alarm #{name} do
   }period #{period}
   statistic #{statistic}
   threshold #{threshold}
-  evaluation_periods #{evaluation_periods}
+  #{treat_missing_data
+  }evaluation_periods #{evaluation_periods}
   #{unit
   }actions_enabled #{actions_enabled}
   alarm_actions #{alarm_actions}

--- a/lib/radiosonde/dsl/treat_missing_data.rb
+++ b/lib/radiosonde/dsl/treat_missing_data.rb
@@ -1,0 +1,22 @@
+class Radiosonde::DSL::TreatMissingData
+  ALIASES = {
+    'breaching'    => :breaching,
+    'notBreaching' => :not_breaching,
+    'ignore'       => :ignore,
+    'missing'      => :missing
+  }
+
+  class << self
+    def conv_to_alias(treat_missing_data)
+      ALIASES[treat_missing_data] || treat_missing_data
+    end
+
+    def valid?(treat_missing_data)
+      ALIASES.keys.include?(treat_missing_data) or ALIASES.values.include?(treat_missing_data)
+    end
+
+    def normalize(treat_missing_data)
+      (ALIASES.respond_to?(:key) ? ALIASES.key(treat_missing_data) : ALIASES.index(treat_missing_data)) || treat_missing_data
+    end
+  end # of class methods
+end

--- a/lib/radiosonde/exporter.rb
+++ b/lib/radiosonde/exporter.rb
@@ -44,6 +44,7 @@ class Radiosonde::Exporter
       :ok_actions => alarm.ok_actions,
       :insufficient_data_actions => alarm.insufficient_data_actions,
       :unit => alarm.unit,
+      :treat_missing_data => alarm.treat_missing_data
     }
 
     if @options[:with_status]

--- a/lib/radiosonde/wrapper/alarm.rb
+++ b/lib/radiosonde/wrapper/alarm.rb
@@ -18,6 +18,7 @@ class Radiosonde::Wrapper::Alarm
     :ok_actions,
     :insufficient_data_actions,
     :actions_enabled,
+    :treat_missing_data
   ]
 
   ATTRIBUTES = [:alarm_name] + ATTRIBUTES_WITHOUT_NAME


### PR DESCRIPTION
I want to be able to handle the TreatMissingData parameter.

AWS Document
https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricAlarm.html
http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarms-and-missing-data

見よう見まねで作ったので、もし不備があればコメントもらえればと思います。