### PR TITLE
Support datapoints_to_alarm method for CloudWatch Alarm.

### DIFF
--- a/lib/radiosonde/dsl/context/alarm.rb
+++ b/lib/radiosonde/dsl/context/alarm.rb
@@ -91,6 +91,11 @@ class Radiosonde::DSL::Context::Alarm
     @result.evaluation_periods = value.to_i
   end
 
+  def datapoints_to_alarm(value)
+    _call_once(:datapoints_to_alarm)
+    @result.datapoints_to_alarm = value.to_i
+  end
+
   def unit(value)
     _call_once(:unit)
     _validate("Invalid value: #{value}") do

--- a/lib/radiosonde/dsl/converter.rb
+++ b/lib/radiosonde/dsl/converter.rb
@@ -41,7 +41,7 @@ class Radiosonde::DSL::Converter
 
     if unit = attrs[:unit]
       unit = Radiosonde::DSL::Unit.conv_to_alias(unit).inspect
-      unit = "unit #{unit}\n"
+      unit = "unit #{unit}\n  "
     end
 
     if treat_missing_data = attrs[:treat_missing_data]

--- a/lib/radiosonde/dsl/converter.rb
+++ b/lib/radiosonde/dsl/converter.rb
@@ -33,6 +33,7 @@ class Radiosonde::DSL::Converter
     statistic = Radiosonde::DSL::Statistic.conv_to_alias(attrs[:statistic]).inspect
     threshold = format_threshold(attrs)
     evaluation_periods = attrs[:evaluation_periods].inspect
+    datapoints_to_alarm = attrs[:datapoints_to_alarm].inspect
     actions_enabled = attrs[:actions_enabled].inspect
     alarm_actions = attrs[:alarm_actions].inspect
     ok_actions = attrs[:ok_actions].inspect
@@ -59,6 +60,7 @@ alarm #{name} do
   threshold #{threshold}
   #{treat_missing_data
   }evaluation_periods #{evaluation_periods}
+  datapoints_to_alarm #{datapoints_to_alarm}
   #{unit
   }actions_enabled #{actions_enabled}
   alarm_actions #{alarm_actions}

--- a/lib/radiosonde/exporter.rb
+++ b/lib/radiosonde/exporter.rb
@@ -39,6 +39,7 @@ class Radiosonde::Exporter
       :threshold => alarm.threshold,
       :comparison_operator => alarm.comparison_operator,
       :evaluation_periods => alarm.evaluation_periods,
+      :datapoints_to_alarm => alarm.datapoints_to_alarm,
       :actions_enabled => alarm.actions_enabled,
       :alarm_actions => alarm.alarm_actions,
       :ok_actions => alarm.ok_actions,

--- a/lib/radiosonde/wrapper/alarm.rb
+++ b/lib/radiosonde/wrapper/alarm.rb
@@ -12,6 +12,7 @@ class Radiosonde::Wrapper::Alarm
     :threshold,
     :comparison_operator,
     :evaluation_periods,
+    :datapoints_to_alarm,
     :actions_enabled,
     :unit,
     :alarm_actions,

--- a/spec/radiosonde_spec.rb
+++ b/spec/radiosonde_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'pp'
 
 describe Radiosonde do
   it 'has a version number' do
@@ -6,8 +7,12 @@ describe Radiosonde do
   end
 end
 
-# describe Radiosonde do
-#   it do
-#     expect(1).to eq(1)
-#   end
-# end
+describe Radiosonde::Exporter do
+  let(:cloudwatch_client) { Aws::CloudWatch::Client.new }
+  let(:cloudwatch_alarm) { Radiosonde::Exporter.new(cloudwatch_client, {}) }
+
+  it 'expect datapoints_to_alarm' do
+    actual = cloudwatch_alarm.export['my-cloudwatch-alarm'][:datapoints_to_alarm]
+    expect(actual).to eq(1)
+  end
+end

--- a/spec/radiosonde_spec.rb
+++ b/spec/radiosonde_spec.rb
@@ -7,12 +7,46 @@ describe Radiosonde do
   end
 end
 
+describe Radiosonde::Client do
+end
+
 describe Radiosonde::Exporter do
   let(:cloudwatch_client) { Aws::CloudWatch::Client.new }
-  let(:cloudwatch_alarm) { Radiosonde::Exporter.new(cloudwatch_client, {}) }
 
-  it 'expect datapoints_to_alarm' do
-    actual = cloudwatch_alarm.export['my-cloudwatch-alarm'][:datapoints_to_alarm]
+  it 'has datapoints_to_alarm' do
+    exporter = Radiosonde::Exporter.new(cloudwatch_client, {})
+    actual = exporter.export['my-cloudwatch-alarm'][:datapoints_to_alarm]
     expect(actual).to eq(1)
+  end
+end
+
+describe Radiosonde::DSL::Converter do
+  let(:cloudwatch_client) { Aws::CloudWatch::Client.new }
+  let(:exporter) { Radiosonde::Exporter.new(cloudwatch_client, {})}
+
+  it 'convert dsl' do
+    dsl = <<-'EOF'
+alarm "my-cloudwatch-alarm" do
+  description "my_NumberOfProcesses"
+  namespace "my-cloudwatch-namespace"
+  metric_name "NumberOfProcesses"
+  dimensions "name"=>"my-dimension"
+  period 300
+  statistic :average
+  threshold "<=", 5.0
+  treat_missing_data :not_breaching
+  evaluation_periods 1
+  datapoints_to_alarm 1
+  unit :seconds
+  actions_enabled true
+  alarm_actions ["arn:aws:sns:ap-northeast-1:1234567890:sns_alert"]
+  ok_actions ["arn:aws:sns:ap-northeast-1:1234567890:sns_alert"]
+  insufficient_data_actions ["arn:aws:sns:ap-northeast-1:1234567890:sns_alert"]
+end
+EOF
+    exported = exporter.export
+    converter = Radiosonde::DSL::Converter.new(exported, {})
+    actual = converter.convert
+    expect(actual).to eq(dsl)
   end
 end

--- a/spec/radiosonde_spec.rb
+++ b/spec/radiosonde_spec.rb
@@ -1,5 +1,13 @@
+require 'spec_helper'
+
 describe Radiosonde do
-  it do
-    expect(1).to eq(1)
+  it 'has a version number' do
+    expect(Radiosonde::VERSION).not_to be nil
   end
 end
+
+# describe Radiosonde do
+#   it do
+#     expect(1).to eq(1)
+#   end
+# end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,48 @@
 require 'radiosonde'
+
+Aws.config.update({
+                    region: 'us-east-1',
+                    credentials: Aws::Credentials.new(
+                      'akid',
+                      'secret')
+                  })
+
+Aws.config[:cloudwatch] = {
+  stub_responses: {
+    describe_alarms: {
+      metric_alarms: [
+        {
+          alarm_name: 'my-cloudwatch-alarm',
+          alarm_arn: 'arn:aws:cloudwatch:ap-northeast-1:1234567890:alarm:my_NumberOfProcesses',
+          alarm_description: 'my_NumberOfProcesses',
+          alarm_configuration_updated_timestamp: Time.new(2015, 1, 2, 10, 00, 00, '+00:00'),
+          actions_enabled: true,
+          ok_actions: ['arn:aws:sns:ap-northeast-1:1234567890:sns_alert'],
+          alarm_actions: ['arn:aws:sns:ap-northeast-1:1234567890:sns_alert'],
+          insufficient_data_actions: ['arn:aws:sns:ap-northeast-1:1234567890:sns_alert'],
+          state_value: 'OK',
+          state_reason: 'Threshold Crossed: 1 datapoint (53.0) was not less than or equal to the threshold (5.0).',
+          state_reason_data:
+            '{\'version\':\'1.0\',\'queryDate\':\'2015-04-04T01:06:26.904+0000\',\'startDate\':\'2015-04-04T01:01:00.000+0000\',\'statistic\':\'Average\',\'period\':300,\'recentDatapoints\':[53.0],\'threshold\':5.0}',
+          state_updated_timestamp: Time.new(2015, 1, 2, 10, 10, 00, '+00:00'),
+          metric_name: 'NumberOfProcesses',
+          namespace: 'my-cloudwatch-namespace',
+          statistic: 'Average',
+          dimensions:
+            [
+              {
+                name: 'name',
+                value: 'my-dimension'
+              }
+            ],
+          period: 300,
+          unit: 'Seconds',
+          evaluation_periods: 1,
+          datapoints_to_alarm: 1,
+          threshold: 5.0,
+          comparison_operator: 'LessThanOrEqualToThreshold'
+        }
+      ]
+    }
+  }
+}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,6 +40,7 @@ Aws.config[:cloudwatch] = {
           evaluation_periods: 1,
           datapoints_to_alarm: 1,
           threshold: 5.0,
+          treat_missing_data: 'notBreaching',
           comparison_operator: 'LessThanOrEqualToThreshold'
         }
       ]


### PR DESCRIPTION
I want to be able to handle the  `datapoints_to_alarm` method.

* https://docs.aws.amazon.com/sdkforruby/api/Aws/CloudWatch/Types/MetricAlarm.html#datapoints_to_alarm-instance_method

Please confirm.

`describe_alarms` に `datapoints_to_alarm` が追加されていたので, 対応しました. 

現状ですと, マネジメントコンソールで `datapoints_to_alarm` を修正して, export した後, 改めて apply すると,  `evaluation_periods` の値で `datapoints_to_alarm` が上書きされる現象を確認しています. (radiosonde-0.2.0.beta4 で確認しております)

お手数ですが, ご確認よろしくお願いいたします.


