### PR TITLE
Remove duplicated attribute definition

### DIFF
--- a/lib/radiosonde/wrapper/alarm.rb
+++ b/lib/radiosonde/wrapper/alarm.rb
@@ -18,7 +18,6 @@ class Radiosonde::Wrapper::Alarm
     :alarm_actions,
     :ok_actions,
     :insufficient_data_actions,
-    :actions_enabled,
     :treat_missing_data
   ]
 


### PR DESCRIPTION
There are two definitions of `actions_enabled` on line 16 and line 21.
https://github.com/codenize-tools/radiosonde/blob/98f3b02fce10db8b82abe0952a3be54ce178a1eb/lib/radiosonde/wrapper/alarm.rb#L16-L21


This pull request remove one of them.